### PR TITLE
feat(flutter-version): semver prereleases, single bump path, tag every commit

### DIFF
--- a/build-number/action.yml
+++ b/build-number/action.yml
@@ -13,5 +13,5 @@ outputs:
   build-number:
     description: 'Generated build number'
 runs:
-  using: node16
+  using: node20
   main: index.js

--- a/create-flutter-release-branch/action.yml
+++ b/create-flutter-release-branch/action.yml
@@ -22,7 +22,6 @@ runs:
     - name: Create Release Branch
       run: |
         git pull
-        level="${{ inputs.level }}"
         CURRENT_VERSION=$(grep -m1 "^version:" pubspec.yaml | sed -E 's/^version: ([0-9]+)\.([0-9]+)\..*/\1.\2/')
         git checkout -b release/${CURRENT_VERSION}
         git push --set-upstream origin release/${CURRENT_VERSION}

--- a/flutter-version/action.yml
+++ b/flutter-version/action.yml
@@ -11,13 +11,25 @@ inputs:
     required: false
     default: 'Big Blue CICD'
   level:
-    description: 'Version Level to Increment'
+    description: 'Version Level to Increment (major | minor | patch | preminor | prerelease)'
     required: false
     default: 'patch'
+  preid:
+    description: 'Pre-Release id used in the -<id>.N suffix on prereleases'
+    required: false
+    default: 'beta'
   token:
     description: 'GitHub token for build number generation'
     required: false
     default: ${{ github.token }}
+
+outputs:
+  current-version:
+    description: 'The new pubspec.yaml version (e.g. 1.2.3-beta.4+685)'
+    value: ${{ steps.bump.outputs.current-version }}
+  build-number:
+    description: 'The integer build number (the value after the + in the pubspec version)'
+    value: ${{ steps.build-number.outputs.build-number }}
 
 runs:
   using: "composite"
@@ -29,74 +41,68 @@ runs:
       shell: bash
     - name: Generate build number
       id: build-number
-      uses: bigblueswimschool/actions/build-number@production
+      uses: bigblueswimschool/actions/build-number@v5
       with:
         token: ${{ inputs.token }}
     - name: Increment ${{ inputs.level }} Version
-      if: "contains(inputs.level, 'prerelease') || contains(inputs.level, 'preminor')"
+      id: bump
+      env:
+        LEVEL: ${{ inputs.level }}
+        PREID: ${{ inputs.preid }}
+        BUILD_NUMBER: ${{ steps.build-number.outputs.build-number }}
       run: |
+        set -euo pipefail
         git pull
         file="pubspec.yaml"
-        level="${{ inputs.level }}"
         version_line=$(grep -m1 "^version:" "$file")
-        if [[ $version_line =~ ([0-9]+)\.([0-9]+)\.([0-9]+)\+([0-9]+) ]]; then
+        re='^version:[[:space:]]*([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z0-9]+)\.([0-9]+))?\+([0-9]+)[[:space:]]*$'
+        if [[ $version_line =~ $re ]]; then
           major="${BASH_REMATCH[1]}"
           minor="${BASH_REMATCH[2]}"
           patch="${BASH_REMATCH[3]}"
-          build="${BASH_REMATCH[4]}"
-          case "$level" in
-            major)
-              major=$((major + 1)); minor=0; patch=0; build=$((build + 1)) ;;
-            preminor)
-              minor=$((minor + 1)); patch=0; build=$((build + 1)) ;;
-            patch)
-              patch=$((patch + 1)); build=$((build + 1)) ;;
-            prerelease)
-              build=$((build + 1)) ;;
-            *)
-              echo "Invalid level: $level. Use major, minor, patch, or build."; exit 1 ;;
-          esac
-          CURRENT_VERSION="$major.$minor.$patch+${{ steps.build-number.outputs.build-number }}"
-          sed -i "s/^version: .*/version: $CURRENT_VERSION/" "$file"
-          echo "Updated version: $CURRENT_VERSION"
+          pre_id="${BASH_REMATCH[5]:-}"
+          pre_num="${BASH_REMATCH[6]:-}"
         else
-          echo "Version not found or invalid format."; exit 1
+          echo "::error::Could not parse pubspec.yaml version line: $version_line"
+          exit 1
         fi
-        
-        git commit -a -m $"Build ${CURRENT_VERSION}" -m "skip ci"
-      shell: bash
-    - name: Increment ${{ inputs.level }} Version
-      if: "!contains(inputs.level, 'prerelease') && !contains(inputs.level, 'preminor')"
-      run: |
-        git pull
-        file="pubspec.yaml"
-        level="${{ inputs.level }}"
-        version_line=$(grep -m1 "^version:" "$file")
-        if [[ $version_line =~ ([0-9]+)\.([0-9]+)\.([0-9]+)\+([0-9]+) ]]; then
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          patch="${BASH_REMATCH[3]}"
-          build="${BASH_REMATCH[4]}"
-          case "$level" in
-            major)
-              major=$((major + 1)); minor=0; patch=0; build=$((build + 1)) ;;
-            minor)
-              minor=$((minor + 1)); patch=0; build=$((build + 1)) ;;
-            patch)
-              patch=$((patch + 1)); build=$((build + 1)) ;;
-            prerelease)
-              build=$((build + 1)) ;;
-            *)
-              echo "Invalid level: $level. Use major, minor, patch, or build."; exit 1 ;;
-          esac
-          CURRENT_VERSION="$major.$minor.$patch+${{ steps.build-number.outputs.build-number }}"
-          sed -i "s/^version: .*/version: $CURRENT_VERSION/" "$file"
-          echo "Updated version: $CURRENT_VERSION"
-        else
-          echo "Version not found or invalid format."; exit 1
+
+        case "$LEVEL" in
+          major)
+            major=$((major + 1)); minor=0; patch=0; pre_id=""; pre_num="" ;;
+          minor)
+            minor=$((minor + 1)); patch=0; pre_id=""; pre_num="" ;;
+          patch)
+            if [[ -n "$pre_num" ]]; then
+              pre_id=""; pre_num=""
+            else
+              patch=$((patch + 1))
+            fi ;;
+          preminor)
+            minor=$((minor + 1)); patch=0; pre_id="$PREID"; pre_num=0 ;;
+          prerelease)
+            if [[ -n "$pre_num" ]]; then
+              pre_num=$((pre_num + 1))
+            else
+              patch=$((patch + 1)); pre_id="$PREID"; pre_num=0
+            fi ;;
+          *)
+            echo "::error::Invalid level: $LEVEL. Use major, minor, patch, preminor, or prerelease."
+            exit 1 ;;
+        esac
+
+        version="$major.$minor.$patch"
+        if [[ -n "$pre_num" ]]; then
+          version="$version-$pre_id.$pre_num"
         fi
-        git commit -a -m $"Build ${CURRENT_VERSION}" -m "skip ci"
-        git tag "$CURRENT_VERSION"
+        version="$version+$BUILD_NUMBER"
+
+        sed -i "s/^version: .*/version: $version/" "$file"
+        echo "Updated version: $version"
+
+        git commit -a -m "Build $version" -m "[skip ci]"
+        git tag "$version"
+        echo "current-version=$version" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Push Version
       run: |


### PR DESCRIPTION
## Summary
Aligns the Flutter mobile-app versioning action with the nest `version` action's semantics so the trunk → release-branch → release flow behaves the same way for both stacks.

- **Semver prereleases.** Develop builds now carry a `-beta.N` suffix (e.g. `0.36.1-beta.5+686`), matching `npm version --preid=beta`. Release-branch builds remain `M.m.p+build`.
- **Tag on every bump.** Previously only non-prerelease bumps created a git tag. Now every commit gets a tag, matching nest.
- **Patch from a prerelease drops the suffix.** `0.36.1-beta.5` patch → `0.36.1`, not `0.36.2`. Matches semver `inc()` semantics; required for the `create-release-branch` flow's "tag current version" step.
- **Single bash block.** The two near-duplicate ~30-line blocks (one for prerelease/preminor, one for the rest) collapse into a single parser/mutator/writer.
- **Outputs.** Adds `current-version` and `build-number` outputs so downstream jobs don't have to re-parse `pubspec.yaml`.
- **Runtime bump.** `build-number/action.yml` moves from `node16` (runner removed mid-2024) to `node20`.
- **Cross-reference.** `flutter-version` now references `build-number@v5` instead of the dead `@production` branch. Consumers should pin to `@v5` after the cut.
- **Cleanup.** Removed an unused `level` shell variable in `create-flutter-release-branch`.

## Verification
Bash logic was tested locally with the full transition matrix (release ↔ prerelease, all five levels) and the full `create-release-branch` simulation:
- develop at `0.36.1-beta.5+686`
- step 1 patch → `0.36.1+687` (tag for release branch)
- step 3 preminor → `0.37.0-beta.0+688` (develop continues)

## Rollout
Per the v5 runbook in the implementation thread:
1. Merge this PR — actions repo CI auto-bumps to `4.1.0-beta.14`.
2. Manually set develop baseline to `5.0.0-beta.0` (`npm version premajor --preid=beta`, push).
3. Dispatch `Create Release Branch` to produce `release/5.0` and tag `v5.0.0`.
4. Land a non-`package.json` commit on `release/5.0` to trigger `tag-release.yml`, which materializes `v5`/`v5.0` aliases via `alias-tags: true`.

The mobile-app PR (https://github.com/bigblueswimschool/mobile-app/pulls — `feat/cicd-versioning-parity`) re-pins consumers to `@v5` and should merge after step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)