### PR TITLE
feat(flutter-version)!: stop incrementing build counter on every bump

### DIFF
--- a/flutter-version/action.yml
+++ b/flutter-version/action.yml
@@ -18,18 +18,11 @@ inputs:
     description: 'Pre-Release id used in the -<id>.N suffix on prereleases'
     required: false
     default: 'beta'
-  token:
-    description: 'GitHub token for build number generation'
-    required: false
-    default: ${{ github.token }}
 
 outputs:
   current-version:
-    description: 'The new pubspec.yaml version (e.g. 1.2.3-beta.4+685)'
+    description: 'The new pubspec.yaml version (e.g. 1.2.3-beta.4)'
     value: ${{ steps.bump.outputs.current-version }}
-  build-number:
-    description: 'The integer build number (the value after the + in the pubspec version)'
-    value: ${{ steps.build-number.outputs.build-number }}
 
 runs:
   using: "composite"
@@ -39,23 +32,19 @@ runs:
         git config --global user.email "${{ inputs.git-user-email }}"
         git config --global user.name "${{ inputs.git-user-name }}"
       shell: bash
-    - name: Generate build number
-      id: build-number
-      uses: bigblueswimschool/actions/build-number@v5
-      with:
-        token: ${{ inputs.token }}
     - name: Increment ${{ inputs.level }} Version
       id: bump
       env:
         LEVEL: ${{ inputs.level }}
         PREID: ${{ inputs.preid }}
-        BUILD_NUMBER: ${{ steps.build-number.outputs.build-number }}
       run: |
         set -euo pipefail
         git pull
         file="pubspec.yaml"
         version_line=$(grep -m1 "^version:" "$file")
-        re='^version:[[:space:]]*([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z0-9]+)\.([0-9]+))?\+([0-9]+)[[:space:]]*$'
+        # +build is accepted for backwards compatibility with old pubspec values
+        # (it gets parsed and discarded; the bump never re-emits it).
+        re='^version:[[:space:]]*([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z0-9]+)\.([0-9]+))?(\+([0-9]+))?[[:space:]]*$'
         if [[ $version_line =~ $re ]]; then
           major="${BASH_REMATCH[1]}"
           minor="${BASH_REMATCH[2]}"
@@ -95,7 +84,6 @@ runs:
         if [[ -n "$pre_num" ]]; then
           version="$version-$pre_id.$pre_num"
         fi
-        version="$version+$BUILD_NUMBER"
 
         sed -i "s/^version: .*/version: $version/" "$file"
         echo "Updated version: $version"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actions",
-    "version": "5.1.0-beta.0",
+    "version": "6.0.0-beta.0",
     "description": "Big Blue Swim School's GitHub Actions",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
Decouples the build-number counter from semver bumps. After this PR, build-N tags are only minted when a store upload actually happens (via `build-and-upload` calling the build-number action directly), not on every prerelease / patch / preminor bump.

## Why
Today's behavior:
- Every develop merge → flutter-version prerelease → build-number action runs → +1 on the counter
- Every commit on a release branch → flutter-version patch → +1 on the counter
- create-release-branch dispatches → 2 more bumps → +2 on the counter

Result: the counter advances ~10× faster than actual store uploads. The build-* tag list grows faster than the build-number action can clean it up (its API call is non-paginated), so old build-* tags accumulate. None of those bumps correspond to a real artifact uploaded to TestFlight or Play Console.

## Changes
- **Remove** the `Generate build number` step inside `flutter-version`.
- **Remove** the `token` input (no longer needed) and the `build-number` output (no longer produced).
- **Stop emitting** the `+build` segment when writing pubspec. The regex still accepts old `+build` values for parsing — they're discarded on the next bump and never re-emitted, so existing pubspecs migrate automatically.

`build-number` action is unchanged and continues to be called by `build-and-upload` per upload.

## Verification
Tested the bump matrix against both legacy (`0.36.0-beta.2+686`) and clean (`0.36.0-beta.5`) pubspec inputs. Old format auto-migrates to clean format on the first bump:

```
0.36.0-beta.2+686  prerelease  -> 0.36.0-beta.3
0.36.0-beta.2+686  patch       -> 0.36.0
0.36.0-beta.2+686  preminor    -> 0.37.0-beta.0
```

Full create-release-branch flow simulated end-to-end:
- develop at `0.36.0-beta.2+686` (legacy)
- step 1 (patch) → `0.36.0` (drops -beta and +build)
- step 3 (preminor) → `0.37.0-beta.0`

## Breaking change semantics
This is a breaking interface change for consumers (output and input shape change), so consumers should pin to `@v6` after the cut. No code consumes the old `build-number` output today (only the `build-and-upload` workflow used it via pubspec, and that path is already independent).

## Rollout
Same playbook as the v5 cut:
1. Merge this PR — actions develop auto-bumps a prerelease.
2. `npm version premajor --preid=beta` to set baseline `6.0.0-beta.0`, push.
3. Dispatch `Create Release Branch` → produces `release/6.0` and `v6.0.0`.
4. Land a non-`package.json` commit on `release/6.0` to trigger `tag-release.yml` and materialize `v6` / `v6.0` aliases.

The mobile-app re-pin PR (forthcoming) is gated on step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)